### PR TITLE
works at small zoom levels using dms

### DIFF
--- a/L.Grid.js
+++ b/L.Grid.js
@@ -60,8 +60,8 @@ L.Grid = L.GeoJSON.extend({
 			if (Math.abs(latLines[i]) > 90) {
 				continue;
 			}
-			grid.push(this._horizontalLine(latLines[i])); // in Graticule this data is put into geojson format, which is probably faster 
-			grid.push(this._label('lat', latLines[i]));  // simple call to line 168: axis, num 
+			grid.push(this._horizontalLine(latLines[i]));  
+			grid.push(this._label('lat', latLines[i]));   
 		}
 				
 		var lngLines = this._lngLines();
@@ -73,7 +73,7 @@ L.Grid = L.GeoJSON.extend({
 		this.eachLayer(this.removeLayer, this);
 
 		for (i in grid) {
-			this.addLayer(grid[i]);   // this where addData would go with a little adjustment to formating, but same info
+			this.addLayer(grid[i]);  
 		}
 		
 		return this;
@@ -83,7 +83,7 @@ L.Grid = L.GeoJSON.extend({
 		return this._lines(
 			this._bounds.getSouth(),
 			this._bounds.getNorth(),
-			this._map.getSize().y/this.options.tickRes, // maybe use getPixelBounds() and some fancy math to calc ticks according to map size
+			this._map.getSize().y/this.options.tickRes, // used to calculate ticks according to map pixel size 
 			this._containsEquator()
 		);
 	},
@@ -91,7 +91,7 @@ L.Grid = L.GeoJSON.extend({
 		return this._lines(
 			this._bounds.getWest(),
 			this._bounds.getEast(),
-			this._map.getSize().x/this.options.tickRes, // maybe use getPixelBounds() and some fancy math to calc ticks according to map size
+			this._map.getSize().x/this.options.tickRes, // used to caclulate ticks according to map pixel size
 			this._containsIRM()
 		);
 	},
@@ -117,9 +117,9 @@ L.Grid = L.GeoJSON.extend({
 		else {var interval = 20; }  
 
 		var tick = interval;
-		// next I need to round 'low' to be evenly divisable by 'tick' aka 'interval'
-		var low = Math.floor((low / tick) - (10)) * tick; // draw 2 extract graticules off the map, for overlap
-		var ticks = ticks + 20; // draw extract graticules, 2 before, 8 after the map bounds
+		// next we need to round 'low' to be evenly divisable by 'tick' aka 'interval'
+		var low = Math.floor((low / tick) - (10)) * tick; // draw 10 extract graticules off the map, for overlap
+		var ticks = ticks + 20; // draw extract graticules, 10 before, 10 after the map bounds
 		var lines = [];
 		for (var i = 1; i <= ticks; i++) {
 			lines.push(low + (i * tick)); 
@@ -151,7 +151,6 @@ L.Grid = L.GeoJSON.extend({
 	},
 
 
-												//////////////////////////////////////////
 	_label: function (axis, num) {   // axis is either the string 'lat' or 'lng', 
 		
 		var latlng;

--- a/L.Grid.js
+++ b/L.Grid.js
@@ -1,14 +1,13 @@
 /*
  * L.Grid displays a grid of lat/lng lines on the map.
+ * 
  */
 
-L.Grid = L.LayerGroup.extend({
+L.Grid = L.GeoJSON.extend({
 	options: {
-		xticks: 8,
-		yticks: 5,
-
+		tickRes: 80, // how many pixels between ticks, good range is between 30 and 200, I like 80
 		// 'decimal' or one of the templates below
-		coordStyle: 'MinDec',
+		coordStyle: 'DMS',
 		coordTemplates: {
 			'MinDec': '{degAbs}&deg;&nbsp;{minDec}\'{dir}',
 			'DMS': '{degAbs}{dir}{min}\'{sec}"'
@@ -21,13 +20,13 @@ L.Grid = L.LayerGroup.extend({
 			opacity: 0.6,
 			weight: 1
 		},
-		
+
 		// Redraw on move or moveend
 		redraw: 'move'
 	},
 
 	initialize: function (options) {
-		L.LayerGroup.prototype.initialize.call(this);
+		L.GeoJSON.prototype.initialize.call(this);
 		L.Util.setOptions(this, options);
 
 	},
@@ -42,7 +41,7 @@ L.Grid = L.LayerGroup.extend({
 
 		this.eachLayer(map.addLayer, map);
 	},
-	
+
 	onRemove: function (map) {
 		// remove layer listeners and elements
 		map.off('viewreset '+ this.options.redraw, this.map);
@@ -51,20 +50,20 @@ L.Grid = L.LayerGroup.extend({
 
 	redraw: function () {
 		// pad the bounds to make sure we draw the lines a little longer
-		this._bounds = this._map.getBounds().pad(0.5);
+		this._bounds = this._map.getBounds();
 
 		var grid = [];
 		var i;
 
-		var latLines = this._latLines();
+		var latLines = this._latLines();  
 		for (i in latLines) {
 			if (Math.abs(latLines[i]) > 90) {
 				continue;
 			}
-			grid.push(this._horizontalLine(latLines[i]));
-			grid.push(this._label('lat', latLines[i]));
+			grid.push(this._horizontalLine(latLines[i])); // in Graticule this data is put into geojson format, which is probably faster 
+			grid.push(this._label('lat', latLines[i]));  // simple call to line 168: axis, num 
 		}
-
+				
 		var lngLines = this._lngLines();
 		for (i in lngLines) {
 			grid.push(this._verticalLine(lngLines[i]));
@@ -74,16 +73,17 @@ L.Grid = L.LayerGroup.extend({
 		this.eachLayer(this.removeLayer, this);
 
 		for (i in grid) {
-			this.addLayer(grid[i]);
+			this.addLayer(grid[i]);   // this where addData would go with a little adjustment to formating, but same info
 		}
+		
 		return this;
 	},
 
-	_latLines: function () {
+	_latLines: function () {     // makes a simple list of latitudes from which to make lines
 		return this._lines(
 			this._bounds.getSouth(),
 			this._bounds.getNorth(),
-			this.options.yticks * 2,
+			this._map.getSize().y/this.options.tickRes, // maybe use getPixelBounds() and some fancy math to calc ticks according to map size
 			this._containsEquator()
 		);
 	},
@@ -91,24 +91,38 @@ L.Grid = L.LayerGroup.extend({
 		return this._lines(
 			this._bounds.getWest(),
 			this._bounds.getEast(),
-			this.options.xticks * 2,
+			this._map.getSize().x/this.options.tickRes, // maybe use getPixelBounds() and some fancy math to calc ticks according to map size
 			this._containsIRM()
 		);
 	},
 
 	_lines: function (low, high, ticks, containsZero) {
-		var delta = low - high,
-			tick = this._round(delta / ticks, delta);
+		var delta = high - low;
+		if (Math.abs(1/3600*ticks - delta) < Math.abs(1/1800*ticks - delta)) { var interval = 1/3600; } // 1"
+		else if (Math.abs(1/1800*ticks - delta) < Math.abs(1/720*ticks - delta)) { var interval = 1/1800; }  // 2"
+		else if (Math.abs(1/720*ticks - delta) < Math.abs(1/360*ticks - delta)) { var interval = 1/720; }    // 5"
+		else if (Math.abs(1/360*ticks - delta) < Math.abs(1/180*ticks - delta)) { var interval = 1/360; }    // 10"
+		else if (Math.abs(1/180*ticks - delta) < Math.abs(1/120*ticks - delta)) { var interval = 1/180; }    // 20"
+		else if (Math.abs(1/120*ticks - delta) < Math.abs(1/60*ticks - delta)) { var interval = 1/120; }     // 30"
+		else if (Math.abs(1/60*ticks - delta) < Math.abs(1/30*ticks - delta)) { var interval = 1/60; }       // 1'
+		else if (Math.abs(1/30*ticks - delta) < Math.abs(1/12*ticks - delta)) { var interval = 1/30; }       // 2'
+		else if (Math.abs(1/12*ticks - delta) < Math.abs(1/6*ticks - delta)) { var interval = 1/12; }        // 5'
+		else if (Math.abs(1/6*ticks - delta) < Math.abs(1/3*ticks - delta)) { var interval = 1/6; }			 // 10'												
+		else if (Math.abs(1/3*ticks - delta) < Math.abs(1/2*ticks - delta)) { var interval = 1/3; }          // 20'
+		else if (Math.abs(1/2*ticks - delta) < Math.abs(ticks - delta)) { var interval = 1/2; }              // 30'
+		else if (Math.abs(ticks - delta) < Math.abs(2*ticks - delta)) { var interval = 1; }              // 1 deg
+		else if (Math.abs(2*ticks - delta) < Math.abs(5*ticks - delta)) { var interval = 2; }              
+		else if (Math.abs(5*ticks - delta) < Math.abs(10*ticks - delta)) { var interval = 5; }             
+		else if (Math.abs(10*ticks - delta) < Math.abs(20*ticks - delta)) { var interval = 10; }           
+		else {var interval = 20; }  
 
-		if (containsZero) {
-			low = Math.floor(low / tick) * tick;
-		} else {
-			low = this._snap(low, tick);
-		}
-
+		var tick = interval;
+		// next I need to round 'low' to be evenly divisable by 'tick' aka 'interval'
+		var low = Math.floor((low / tick) - (10)) * tick; // draw 2 extract graticules off the map, for overlap
+		var ticks = ticks + 20; // draw extract graticules, 2 before, 8 after the map bounds
 		var lines = [];
-		for (var i = -1; i <= ticks; i++) {
-			lines.push(low - (i * tick));
+		for (var i = 1; i <= ticks; i++) {
+			lines.push(low + (i * tick)); 
 		}
 		return lines;
 	},
@@ -125,47 +139,24 @@ L.Grid = L.LayerGroup.extend({
 
 	_verticalLine: function (lng) {
 		return new L.Polyline([
-			[this._bounds.getNorth(), lng],
-			[this._bounds.getSouth(), lng]
+			[this._bounds.getNorth()*1.2, lng], // this creates overlap, helps when printing.
+			[this._bounds.getSouth()/2, lng]
 		], this.options.lineStyle);
 	},
-	_horizontalLine: function (lat) {
+	_horizontalLine: function (lat) {  // this makes a standard geojson LineString, I think
 		return new L.Polyline([
-			[lat, this._bounds.getWest()],
-			[lat, this._bounds.getEast()]
+			[lat, this._bounds.getWest()*1.2],
+			[lat, this._bounds.getEast()/2]
 		], this.options.lineStyle);
 	},
 
-	_snap: function (num, gridSize) {
-		return Math.floor(num / gridSize) * gridSize;
-	},
 
-	_round: function (num, delta) {
-		var ret;
-
-		delta = Math.abs(delta);
-		if (delta >= 1) {
-			if (Math.abs(num) > 1) {
-				ret = Math.round(num);
-			} else {
-				ret = (num < 0) ? Math.floor(num) : Math.ceil(num);
-			}
-		} else {
-			var dms = this._dec2dms(delta);
-			if (dms.min >= 1) {
-				ret = Math.ceil(dms.min) * 60;
-			} else {
-				ret = Math.ceil(dms.minDec * 60);
-			}
-		}
-
-		return ret;
-	},
-
-	_label: function (axis, num) {
+												//////////////////////////////////////////
+	_label: function (axis, num) {   // axis is either the string 'lat' or 'lng', 
+		
 		var latlng;
 		var bounds = this._map.getBounds().pad(-0.005);
-
+		
 		if (axis == 'lng') {
 			latlng = L.latLng(bounds.getNorth(), num);
 		} else {
@@ -210,16 +201,15 @@ L.Grid = L.LayerGroup.extend({
 			return num.toFixed(digits);
 		} else {
 			// Calculate some values to allow flexible templating
-			var dms = this._dec2dms(num);
-
+			var dms = this._dec2dms(Math.abs(num) + 0.000014); // this rounds it up so you get something like '60' instead of 59.999999
 			var dir;
 			if (dms.deg === 0) {
 				dir = '&nbsp;';
 			} else {
 				if (axis == 'lat') {
-					dir = (dms.deg > 0 ? 'N' : 'S');
+					dir = (num > 0 ? 'N' : 'S');
 				} else {
-					dir = (dms.deg > 0 ? 'E' : 'W');
+					dir = (num > 0 ? 'E' : 'W');
 				}
 			}
 
@@ -227,7 +217,7 @@ L.Grid = L.LayerGroup.extend({
 				this.options.coordTemplates[style],
 				L.Util.extend(dms, {
 					dir: dir,
-					minDec: Math.round(dms.minDec, 2)
+					sec: Math.round(dms.sec)
 				})
 			);
 		}


### PR DESCRIPTION
The number of grid lines (aka graticules) are calculated automatically based on the pixel size of the map. You can change the density of grid lines by changing tickRes.  _round and _snap were replaced by prescribed intervals between grid lines.  These prescribed intervals only work well with dms. Deg/minDec would need to have a it's own prescribed intervals defined. 
